### PR TITLE
sys: Use includes from php-config --include-dir

### DIFF
--- a/ivory/sys/wrapper.h
+++ b/ivory/sys/wrapper.h
@@ -1,5 +1,9 @@
 #ifndef PHP_RS_WRAPPER_H
 #define PHP_RS_WRAPPER_H
+/* CLang doesn't support asm goto yet, so let's force-disable it. */
+#include <main/php_config.h>
+#undef HAVE_ASM_GOTO
+
 #include <Zend/zend.h>
 #include <Zend/zend_compile.h>
 #include <main/php.h>


### PR DESCRIPTION
If PHP headers are already available, it feels kinda redundant to clone the PHP sources and rebuild them again just to generate bindings. So if `php-config` is available in `$PATH`, we don't clone + compile anymore but use the include directory printed via `php-config --include-dir`.

Unfortunately CLang doesn't yet support `asm goto`, so we now include php_config.h very early and undef `HAVE_ASM_GOTO` thereafter. The `#ifndef` wrapper in `php_config.h` will prevent a second inclusion, so we don't get `HAVE_ASM_GOTO` defined again.